### PR TITLE
Fix the bug, that the music will pause on iOS

### DIFF
--- a/ios/Classes/SwiftFlutterVolumeControllerPlugin.swift
+++ b/ios/Classes/SwiftFlutterVolumeControllerPlugin.swift
@@ -1,12 +1,18 @@
+import AVFoundation
 import Flutter
 import UIKit
-import AVFoundation
 
 public class SwiftFlutterVolumeControllerPlugin: NSObject, FlutterPlugin {
-    private let audioSession: AVAudioSession = AVAudioSession.sharedInstance()
+    private static var audioSession: AVAudioSession {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try? session.setCategory(AVAudioSession.Category.ambient)
+        }
+        return session
+    }
     
-    private static let volumeController: VolumeController = VolumeController()
-    private static let volumeListener: VolumeListener = VolumeListener()
+    private static let volumeController: VolumeController = .init(audioSession: audioSession)
+    private static let volumeListener: VolumeListener = .init(audioSession: audioSession)
     
     public static func register(with registrar: FlutterPluginRegistrar) {
         let methodChannel = FlutterMethodChannel(
@@ -89,11 +95,11 @@ public class SwiftFlutterVolumeControllerPlugin: NSObject, FlutterPlugin {
     }
 }
 
-extension SwiftFlutterVolumeControllerPlugin : FlutterApplicationLifeCycleDelegate {
+extension SwiftFlutterVolumeControllerPlugin: FlutterApplicationLifeCycleDelegate {
     public func applicationWillEnterForeground(_ application: UIApplication) {
         if SwiftFlutterVolumeControllerPlugin.volumeListener.isListening {
             do {
-                try audioSession.setActive(true)
+                try SwiftFlutterVolumeControllerPlugin.audioSession.setActive(true)
             } catch {
                 print("Error reactivating audio session")
             }

--- a/ios/Classes/VolumeController.swift
+++ b/ios/Classes/VolumeController.swift
@@ -5,13 +5,18 @@
 //  Created by yosemiteyss on 17/9/2022.
 //
 
-import Foundation
 import AVFoundation
+import Foundation
 import MediaPlayer
 
 class VolumeController {
-    private let volumeView: MPVolumeView = MPVolumeView()
-    private let audioSession: AVAudioSession = AVAudioSession.sharedInstance()
+    init(audioSession: AVAudioSession) {
+        self.audioSession = audioSession
+    }
+    
+    private let audioSession: AVAudioSession
+    
+    private let volumeView: MPVolumeView = .init()
     
     private var savedVolume: Float?
     
@@ -20,22 +25,22 @@ class VolumeController {
     }
     
     func setVolume(_ volume: Double, showSystemUI: Bool) {
-        setShowSystemUI(showSystemUI);
+        setShowSystemUI(showSystemUI)
         volumeView.setVolume(volume)
     }
     
     func raiseVolume(_ step: Double?, showSystemUI: Bool) {
-        setShowSystemUI(showSystemUI);
+        setShowSystemUI(showSystemUI)
         volumeView.raiseVolume(step ?? 0.15)
     }
     
     func lowerVolume(_ step: Double?, showSystemUI: Bool) {
-        setShowSystemUI(showSystemUI);
+        setShowSystemUI(showSystemUI)
         volumeView.lowerVolume(step ?? 0.15)
     }
     
     func getMute() throws -> Bool {
-        return try getVolume() == 0;
+        return try getVolume() == 0
     }
     
     func setMute(_ isMuted: Bool, showSystemUI: Bool) throws {
@@ -43,7 +48,7 @@ class VolumeController {
         if isMuted {
             savedVolume = try getVolume()
             setVolume(0, showSystemUI: showSystemUI)
-            return;
+            return
         }
         
         // Restore to the volume level before mute.
@@ -70,4 +75,3 @@ class VolumeController {
         }
     }
 }
-

--- a/ios/Classes/VolumeListener.swift
+++ b/ios/Classes/VolumeListener.swift
@@ -5,17 +5,20 @@
 //  Created by yosemiteyss on 18/9/2022.
 //
 
-import Foundation
 import AVFoundation
+import Foundation
 
 class VolumeListener: NSObject, FlutterStreamHandler {
-    private let audioSession: AVAudioSession = AVAudioSession.sharedInstance()
+    init(audioSession: AVAudioSession) {
+        self.audioSession = audioSession
+    }
+    
+    private let audioSession: AVAudioSession
+    
     private var outputVolumeObservation: NSKeyValueObservation?
     
     var isListening: Bool {
-        get {
-            return outputVolumeObservation != nil
-        }
+        return outputVolumeObservation != nil
     }
     
     func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {


### PR DESCRIPTION
I found a bug, that the music stops playing as soon you start listen or read the volume. This happens because the default category don't allow to mix music with other apps. Now, when for example Spotify is playing the music will not stop playing on both events. 

That's why I added the Category ambient to the AVAudioSession. Also, to have only one instance, I provide the session to both models.

For reading: https://developer.apple.com/documentation/avfaudio/avaudiosessioncategory

Ambient: 
> The category for an app in which sound playback is nonprimary — that is, your app also works with the sound turned 

```swift
 private static var audioSession: AVAudioSession {
        let session = AVAudioSession.sharedInstance()
        do {
            try? session.setCategory(AVAudioSession.Category.ambient)
        }
        return session
    }
```

Maybe, for a better use case : enable to set the options from Flutter?