### PR TITLE
fix(ohos): cannot set volume on first attempt

### DIFF
--- a/ohos/src/main/ets/components/plugin/Extensions.ets
+++ b/ohos/src/main/ets/components/plugin/Extensions.ets
@@ -35,16 +35,63 @@ function VolumePanel(param: VolumeParams) {
 export class VolumePanelNode extends NodeController {
   private node: BuilderNode<[VolumeParams]> | null = null;
   private volumeParams = new VolumeParams();
+  private context?: common.UIAbilityContext;
+  private initializing: boolean = false;
+  private disposed: boolean = false;
+  private retryTimer?: number;
 
   constructor(ctx?: common.UIAbilityContext) {
     super();
-    const windowStage = ctx?.windowStage;
-    try {
-      const ctx = windowStage?.getMainWindowSync().getUIContext();
-      this.node = new BuilderNode(ctx!);
-      this.node.build(wrapBuilder<[VolumeParams]>(VolumePanel), this.volumeParams);
-    } catch (e) {
+    this.context = ctx;
+    this.ensureInitialized();
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    if (this.retryTimer !== undefined) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = undefined;
     }
+  }
+
+  ensureInitialized(): void {
+    if (this.disposed || this.node || this.initializing) {
+      return;
+    }
+
+    const windowStage = this.context?.windowStage;
+    if (!windowStage) {
+      this.scheduleRetry();
+      return;
+    }
+
+    this.initializing = true;
+    windowStage.getMainWindow().then((mainWindow) => {
+      this.initializing = false;
+      if (this.disposed || this.node) {
+        return;
+      }
+      try {
+        this.node = new BuilderNode(mainWindow.getUIContext());
+        this.node.build(wrapBuilder<[VolumeParams]>(VolumePanel), this.volumeParams);
+      } catch (_) {
+        this.node = null;
+        this.scheduleRetry();
+      }
+    }).catch(() => {
+      this.initializing = false;
+      this.scheduleRetry();
+    });
+  }
+
+  private scheduleRetry(): void {
+    if (this.disposed || this.node || this.retryTimer !== undefined) {
+      return;
+    }
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = undefined;
+      this.ensureInitialized();
+    }, 50);
   }
 
   makeNode(_: UIContext): FrameNode | null {
@@ -55,16 +102,20 @@ export class VolumePanelNode extends NodeController {
    * @param vol - AVVolumePanel receive volume from 0 to 15
    */
   changeVolume(vol: number) {
+    this.volumeParams.volume = Math.round(vol);
     if (this.node) {
-      this.volumeParams.volume = Math.round(vol);
       this.node.update(this.volumeParams);
+      return;
     }
+    this.ensureInitialized();
   }
 
   changeShowSystemUI(show: boolean) {
+    this.volumeParams.showSystemUI = show;
     if (this.node) {
-      this.volumeParams.showSystemUI = show;
       this.node.update(this.volumeParams);
+      return;
     }
+    this.ensureInitialized();
   }
 }

--- a/ohos/src/main/ets/components/plugin/FlutterVolumeControllerPlugin.ets
+++ b/ohos/src/main/ets/components/plugin/FlutterVolumeControllerPlugin.ets
@@ -30,9 +30,15 @@ export default class FlutterVolumeControllerPlugin implements FlutterPlugin, Met
 
   onAttachedToAbility(binding: AbilityPluginBinding): void {
     this.context = binding.getAbility().context;
+    this.volumePanel = new VolumePanelNode(this.context);
+    this.volumeController = new VolumeController(this.volumePanel);
   }
 
   onDetachedFromAbility(): void {
+    this.volumePanel?.dispose();
+    this.volumePanel = undefined;
+    this.volumeController = undefined;
+    this.context = undefined;
   }
 
   getUniqueClassName(): string {
@@ -52,7 +58,6 @@ export default class FlutterVolumeControllerPlugin implements FlutterPlugin, Met
   }
 
   onMethodCall(call: MethodCall, result: MethodResult): void {
-    this.initVolumePanel();
     switch (call.method) {
       case MethodName.GET_VOLUME:
         try {
@@ -125,13 +130,6 @@ export default class FlutterVolumeControllerPlugin implements FlutterPlugin, Met
       default:
         result.notImplemented();
         break;
-    }
-  }
-
-  private initVolumePanel() {
-    if (!this.volumePanel && !this.volumeController) {
-      this.volumePanel = new VolumePanelNode(this.context);
-      this.volumeController = new VolumeController(this.volumePanel);
     }
   }
 }

--- a/ohos/src/main/ets/components/plugin/VolumeStreamHandler.ets
+++ b/ohos/src/main/ets/components/plugin/VolumeStreamHandler.ets
@@ -14,7 +14,7 @@ export class VolumeStreamHandler implements StreamHandler {
       const argsMap = args as Map<string, Object>;
       const emitOnStart = argsMap.get(MethodArg.EMIT_ON_START) as boolean;
 
-      this.audioVolumeManager.on('streamVolumeChange', audio.StreamUsage.STREAM_USAGE_MOVIE, (event) => {
+      this.audioVolumeManager.on('streamVolumeChange', this.streamUsage, (event) => {
         events.success((1 / this.maxVolume * event.volume).toString());
       });
 


### PR DESCRIPTION
This PR fix a problem caused by `VolumePanelNode` initialization. previously it will initialize when first method call, synchronously. It leads to failure during the first attempt to set volume. Now it will initialize during `onAttachedToAbility`, with retry logic to make sure it is only initialized when the `windowStage` is available.